### PR TITLE
Typo in struct comment: autenticated/authenticated

### DIFF
--- a/registry/auth/auth.go
+++ b/registry/auth/auth.go
@@ -38,7 +38,7 @@ import (
 )
 
 // UserInfo carries information about
-// an autenticated/authorized client.
+// an authenticated/authorized client.
 type UserInfo struct {
 	Name string
 }


### PR DESCRIPTION
The title says it all.
